### PR TITLE
Fix selinux denials when restarting bluetooth service.

### DIFF
--- a/sepolicy/bluetooth_loader.te
+++ b/sepolicy/bluetooth_loader.te
@@ -17,6 +17,7 @@ domain_auto_trans(bluetooth_loader, hci_attach_exec, hci_attach)
 allow hci_attach bluetooth_loader:fd use;
 
 # Read mac address from persist partition
+allow bluetooth_loader misc_partition:blk_file { getattr open read };
 allow bluetooth_loader persist_file:dir search;
 r_dir_file(bluetooth_loader, persist_bluetooth_file)
 


### PR DESCRIPTION
Fixes problem with having to pair bluetooth devices over again after restarting the bluetooth service. It works for the LG G Pad 8.3 http://review.cyanogenmod.org/#/c/93433/
